### PR TITLE
Update main.py

### DIFF
--- a/gtdbtk/main.py
+++ b/gtdbtk/main.py
@@ -719,6 +719,8 @@ class OptionsParser(object):
             options.max_consensus = None
             options.rnd_seed = None
             options.skip_trimming = False
+            options.scratch_dir = None
+            options.recalculate_red = False
 
             self.align(options)
 


### PR DESCRIPTION
Added options.scratch_dir and options.recalculate_red on line 722 and 723 to prevent an error "Namespace does not exist" while running classify_wf.